### PR TITLE
`HACS` Github action to ignore brands registration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: integration
+          ignore: brands
 
   tests:
     name: Tests


### PR DESCRIPTION
* `hacs` Github action now skips checking if the integration is added to HomeAssistant brands (not at this moment)