### PR TITLE
Fixed translations

### DIFF
--- a/custom_components/oidc_userinfo/strings.json
+++ b/custom_components/oidc_userinfo/strings.json
@@ -1,10 +1,5 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "description": "Do you want to add OIDC UserInfo to Home Assistant?"
-      }
-    },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }

--- a/custom_components/oidc_userinfo/strings.json
+++ b/custom_components/oidc_userinfo/strings.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "step": {},
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }

--- a/custom_components/oidc_userinfo/translations/en.json
+++ b/custom_components/oidc_userinfo/translations/en.json
@@ -1,0 +1,7 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Already configured. Only a single configuration possible."
+        }
+    }
+}

--- a/custom_components/oidc_userinfo/translations/en.json
+++ b/custom_components/oidc_userinfo/translations/en.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "step": {},
         "abort": {
             "single_instance_allowed": "Already configured. Only a single configuration possible."
         }


### PR DESCRIPTION
* `strings.json`: Removed unised entry for `config.step.user`
* Added EN translation