### PR TITLE
chore: Update to recent HomeAssistant and testing tools versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,11 +34,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310
+            python: '3.12'
+            toxenv: py312
           - os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311
+            python: '3.13'
+            toxenv: py313
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code

--- a/custom_components/oidc_userinfo/config_flow.py
+++ b/custom_components/oidc_userinfo/config_flow.py
@@ -2,7 +2,7 @@
 ConfigFlow support for the custom component.
 """
 from __future__ import annotations
-from typing import Any
+from typing import Any, Self
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
@@ -27,3 +27,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         return self.async_create_entry(title=TITLE, data={})
+
+    def is_matching(self, other_flow: Self) -> bool:
+        """
+        Determine if there is another flow for the same entity running already.
+
+        Not currently implemented, and only used to prevent `pylint` from
+        erroring out stating the method is abstract in the base class:
+
+            W0223: Method 'is_matching' is abstract in class 'ConfigFlow'
+            but is not overridden in child class 'ConfigFlow' (abstract-method)
+        """
+        raise NotImplementedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,5 @@ log_cli_level = "error"
 # Workaround for
 # https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/129
 asyncio_mode = "auto"
+# Introduced by `pytest-asyncio` recently
+asyncio_default_fixture_loop_scope = "function"

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,6 @@ deps =
     pytest-cov==5.0.0
     pytest-asyncio==0.24.0
     flake8==7.1.1
-    # Required for `http` component being dependency
-    aiohttp_cors==0.7.0
 
 setenv =
 	# Allow tests to import the custom compontent using

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{310,311}
+envlist = py{312,313}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -16,32 +16,17 @@ isolated_build = true
 # methods
 skipsdist=true
 
-[testenv:py311]
-deps =
-    coverage==7.2.7
-    pytest-homeassistant-custom-component==0.13.53
-    pytest-cov==4.1.0
-	pytest-asyncio==0.21.0
-	{[testenv]deps}
-
-[testenv:py310]
-deps =
-	coverage==7.2.4
-	pytest-homeassistant-custom-component==0.13.45
-	pytest-cov==3.0.0
-	pytest-asyncio==0.20.3
-	{[testenv]deps}
-
 [testenv]
 deps =
-    flake8==6.1.0
-    pylint==2.17.5
-    pytest==7.3.1
+    coverage==7.6.1
+    pylint==3.3.1
+    pytest==8.3.3
+    pytest-homeassistant-custom-component==0.13.184
+    pytest-cov==5.0.0
+    pytest-asyncio==0.24.0
+    flake8==7.1.1
     # Required for `http` component being dependency
     aiohttp_cors==0.7.0
-
-allowlist_externals =
-	cat
 
 setenv =
 	# Allow tests to import the custom compontent using
@@ -50,11 +35,7 @@ setenv =
 
 commands =
     flake8 --tee --output-file=flake8.txt custom_components/ tests/
-    pylint --output-format=parseable --output=pylint.txt custom_components/ tests/
-	# Ensure only traces for in-repository module is processed, not for one
-	# installed by `tox` (see above for more details)
+    pylint --output-format=text,parseable:pylint.txt custom_components/ tests/
+    # Ensure only traces for in-repository module is processed, not for one
+    # installed by `tox` (see above for more details)
     pytest --cov=custom_components/ --cov-append --cov-report=term-missing -v tests/ []
-
-commands_post =
-	# Show the `pylint` report to the standard output, to ease fixing the issues reported
-	cat pylint.txt


### PR DESCRIPTION
* Tests and their dependencies have been updated to use latest HomeAssistant version (provided by `pytest-homeassistant-custom-component` package) and most recent versions of testing toolset
* Support for testing under Python < 3.12 has been removed (newer HASS uses 3.12 and higher)
* `config_flow.py` has been updated to include a dummy implementation of `is_matching` method, to prevent `pylint` from erroring out
* Github Actions: updated Python versions used for testing
* `tox`: Explicitly specifying `aiohttp_cors`  dependency is no longer required for recent HASS versions
