### PR TITLE
feat: Use configured HASS URLs to determine user domain

### DIFF
--- a/custom_components/oidc_userinfo/__init__.py
+++ b/custom_components/oidc_userinfo/__init__.py
@@ -63,7 +63,11 @@ class CurrentUserView(HomeAssistantView):
         hass_host = 'homeassistant.local'
         # Attempt to determine the host from HomeAssistant URL
         with suppress(NoURLAvailableError):
-            hass_host = yarl.URL(get_url(hass, allow_ip=True)).host
+            hass_host = yarl.URL(
+                # Prefer external URL if configured in HASS, failling back to 
+                # internal
+                get_url(hass, allow_ip=True, prefer_external=True)
+            ).host
 
         # Determine user name from authentication provider(s)
         user_name = user.name

--- a/custom_components/oidc_userinfo/__init__.py
+++ b/custom_components/oidc_userinfo/__init__.py
@@ -64,7 +64,7 @@ class CurrentUserView(HomeAssistantView):
         # Attempt to determine the host from HomeAssistant URL
         with suppress(NoURLAvailableError):
             hass_host = yarl.URL(
-                # Prefer external URL if configured in HASS, failling back to 
+                # Prefer external URL if configured in HASS, failling back to
                 # internal
                 get_url(hass, allow_ip=True, prefer_external=True)
             ).host

--- a/tests/test_auth_user.py
+++ b/tests/test_auth_user.py
@@ -46,7 +46,7 @@ async def test_auth_user_not_authenticated(hass):
 
 
 @pytest.mark.parametrize('hass_config_urls,expected_user_domain', [
-    # Both external and internal URLs are provided, external one should be 
+    # Both external and internal URLs are provided, external one should be
     # selected
     (
         {

--- a/tests/test_auth_user.py
+++ b/tests/test_auth_user.py
@@ -45,10 +45,33 @@ async def test_auth_user_not_authenticated(hass):
         )(request)
 
 
-async def test_auth_user(hass, hass_admin_credential, hass_admin_user):
+@pytest.mark.parametrize('hass_config_urls,expected_user_domain', [
+    # Both external and internal URLs are provided, external one should be 
+    # selected
+    (
+        {
+            'external_url': 'https://test.url',
+            'internal_url': 'http://localhost'
+        },
+        'test.url'
+    ),
+    # Only external URL is provided, should be selecte
+    ({'external_url': 'https://test.url'}, 'test.url'),
+    # Same but for internal one
+    ({'internal_url': 'http://localhost'}, 'localhost'),
+    # None of URLs are configured in HASS, should fall back to
+    # `homeassistant.local`
+    ({}, 'homeassistant.local'),
+])
+async def test_auth_user(
+    hass, hass_admin_credential, hass_admin_user, hass_config_urls,
+    expected_user_domain
+):
     """
     Tests for correct response from the view when client is authenticated
     """
+    hass.config.external_url = hass_config_urls.get('external_url', None)
+    hass.config.internal_url = hass_config_urls.get('internal_url', None)
     # Link admin user and its credentials (both mocked) together
     await hass.auth.async_link_user(hass_admin_user, hass_admin_credential)
     request = MockWebRequest(
@@ -82,7 +105,7 @@ async def test_auth_user(hass, hass_admin_credential, hass_admin_user):
     assert response_obj == {
         # The domain should fallback to `homeassistant.local` since no real
         # networking is available
-        'email': f'{user_name}@homeassistant.local',
+        'email': f'{user_name}@{expected_user_domain}',
         'sub': hass_admin_user.id,
         'name': hass_admin_user.name,
     }


### PR DESCRIPTION
* Response from the `userinfo` OAuth2 endpoint now considers HASS URLs configured for domain of the user email (`email` claim) - external URL is considered first (if configured), then internal (if configured) and finally falls back to `homeassistant.local` if none are available